### PR TITLE
adds space control for audio pausing

### DIFF
--- a/components/app/LearningMode.tsx
+++ b/components/app/LearningMode.tsx
@@ -31,6 +31,8 @@ export function LearningMode({ state, audio, onGoHome }: LearningModeProps) {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [fullReviewRevealed, setFullReviewRevealed] = useState(false);
   const [allSubmitted, setAllSubmitted] = useState(false);
+  const [audioAllTargetsRevealed, setAudioAllTargetsRevealed] = useState(true);
+  const [audioRevealNonce, setAudioRevealNonce] = useState(0);
 
   const cardId = state.status === 'reviewing' ? state.cardId : null;
   useEffect(() => {
@@ -38,7 +40,25 @@ export function LearningMode({ state, audio, onGoHome }: LearningModeProps) {
     setAllSubmitted(false);
   }, [cardId]);
 
+  const reviewingReviewMode =
+    state.status === 'reviewing'
+      ? (state.courseSettings.reviewMode ?? 'audio')
+      : null;
+  const reviewingHideTargets =
+    state.status === 'reviewing'
+      ? (state.courseSettings.hideTargetLanguages ?? true)
+      : null;
+
+  useEffect(() => {
+    if (reviewingReviewMode !== 'audio' || reviewingHideTargets === null) return;
+    setAudioAllTargetsRevealed(!reviewingHideTargets);
+    setAudioRevealNonce(0);
+  }, [cardId, reviewingReviewMode, reviewingHideTargets]);
+
   const handleReveal = useCallback(() => setFullReviewRevealed(true), []);
+  const handleRevealAllAudioTargets = useCallback(() => {
+    setAudioRevealNonce((n) => n + 1);
+  }, []);
   const handleEdit = useCallback(() => {
     audio.pause();
     setEditDialogOpen(true);
@@ -159,6 +179,8 @@ export function LearningMode({ state, audio, onGoHome }: LearningModeProps) {
         autoRevealLanguages={state.courseSettings.autoRevealLanguages ?? true}
         revealedLanguages={audio.revealedLanguages}
         showRomanization={state.courseSettings.showRomanization ?? true}
+        revealAllSignal={audioRevealNonce}
+        onAllTargetsRevealedChange={setAudioAllTargetsRevealed}
       />
     );
 
@@ -201,6 +223,9 @@ export function LearningMode({ state, audio, onGoHome }: LearningModeProps) {
         fullReviewRevealed={fullReviewRevealed || allSubmitted}
         onReveal={handleReveal}
         shortcutsDisabled={state.settingsOpen || editDialogOpen}
+        isAudioReview={reviewMode === 'audio'}
+        audioAllTargetsRevealed={audioAllTargetsRevealed}
+        onRevealAllAudioTargets={handleRevealAllAudioTargets}
       />
 
       <LearningModeSettings

--- a/components/app/LearningMode.tsx
+++ b/components/app/LearningMode.tsx
@@ -63,6 +63,7 @@ export function LearningMode({ state, audio, onGoHome }: LearningModeProps) {
           onNext={() => {}}
           isReviewing={true}
           showProgressBar={false}
+          shortcutsDisabled={state.settingsOpen}
         />
       </div>
     );
@@ -199,6 +200,7 @@ export function LearningMode({ state, audio, onGoHome }: LearningModeProps) {
         isFullReview={reviewMode === 'full'}
         fullReviewRevealed={fullReviewRevealed || allSubmitted}
         onReveal={handleReveal}
+        shortcutsDisabled={state.settingsOpen || editDialogOpen}
       />
 
       <LearningModeSettings

--- a/components/app/learning/LearningCardContent.tsx
+++ b/components/app/learning/LearningCardContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { AudioButton } from './AudioButton';
 import { CardShell } from './CardShell';
 import type { CardTranslation, CardAudioRecording } from './types';
@@ -24,6 +24,10 @@ interface LearningCardContentProps {
   hideTargetLanguages?: boolean;
   autoRevealLanguages?: boolean;
   revealedLanguages?: ReadonlySet<string>;
+  /** When this value changes (e.g. incremented by parent), all target lines are manually revealed. */
+  revealAllSignal?: number;
+  /** Reports whether every target translation is visible (not blurred). */
+  onAllTargetsRevealedChange?: (allRevealed: boolean) => void;
   bare?: boolean;
   showRomanization?: boolean;
 }
@@ -46,6 +50,8 @@ export function LearningCardContent({
   hideTargetLanguages = false,
   autoRevealLanguages = false,
   revealedLanguages,
+  revealAllSignal = 0,
+  onAllTargetsRevealedChange,
   bare = false,
   showRomanization = true,
 }: LearningCardContentProps) {
@@ -55,6 +61,10 @@ export function LearningCardContent({
       : preReviewCount;
 
   const [manuallyRevealed, setManuallyRevealed] = useState<Set<string>>(new Set());
+
+  // Capture the signal value at mount so we don't treat a stale non-zero value
+  // (left over from the previous card) as a fresh "reveal all" request.
+  const mountRevealSignalRef = useRef(revealAllSignal);
 
   const translationKey = translations.map((tr) => tr.language + tr.text).join('|');
   const [prevTranslationKey, setPrevTranslationKey] = useState(translationKey);
@@ -70,6 +80,41 @@ export function LearningCardContent({
       return next;
     });
   };
+
+  const targetLanguages = useMemo(
+    () => translations.filter((tr) => tr.isTargetLanguage).map((tr) => tr.language),
+    [translations],
+  );
+
+  const allTargetsRevealed = useMemo(() => {
+    if (!hideTargetLanguages) return true;
+    return targetLanguages.every((lang) => {
+      const isAudioRevealed =
+        autoRevealLanguages && (revealedLanguages?.has(lang) ?? false);
+      return isAudioRevealed || manuallyRevealed.has(lang);
+    });
+  }, [
+    hideTargetLanguages,
+    targetLanguages,
+    autoRevealLanguages,
+    revealedLanguages,
+    manuallyRevealed,
+  ]);
+
+  useEffect(() => {
+    onAllTargetsRevealedChange?.(allTargetsRevealed);
+  }, [allTargetsRevealed, onAllTargetsRevealedChange]);
+
+  useEffect(() => {
+    if (revealAllSignal === 0 || revealAllSignal === mountRevealSignalRef.current) return;
+    setManuallyRevealed((prev) => {
+      const next = new Set(prev);
+      for (const lang of targetLanguages) {
+        next.add(lang);
+      }
+      return next;
+    });
+  }, [revealAllSignal, targetLanguages]);
 
   return (
     <div data-tutorial="card-content" className="flex flex-col flex-1 min-h-0">

--- a/components/app/learning/LearningControls.tsx
+++ b/components/app/learning/LearningControls.tsx
@@ -81,11 +81,22 @@ export function LearningControls({
       if (
         target instanceof HTMLInputElement ||
         target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
         (target instanceof HTMLElement && target.isContentEditable)
       ) {
         return;
       }
       if (e.key === ' ' || e.code === 'Space') {
+        // Let Space activate focused interactive controls so keyboard
+        // navigation and accessibility are not broken.
+        if (
+          target instanceof HTMLElement &&
+          target.closest(
+            'button, a, select, [role="button"], [role="link"], [role="menuitem"], [role="checkbox"], [role="radio"], [role="tab"]',
+          )
+        ) {
+          return;
+        }
         if (e.repeat || isMerging || durationSec === 0) return;
         e.preventDefault();
         if (isPlaying) {

--- a/components/app/learning/LearningControls.tsx
+++ b/components/app/learning/LearningControls.tsx
@@ -28,6 +28,8 @@ interface LearningControlsProps {
   isFullReview?: boolean;
   fullReviewRevealed?: boolean;
   onReveal?: () => void;
+  /** When true, window shortcuts (Space, Enter, rating keys) are disabled — e.g. settings or edit dialog open. */
+  shortcutsDisabled?: boolean;
 }
 
 export function LearningControls({
@@ -49,6 +51,7 @@ export function LearningControls({
   isFullReview = false,
   fullReviewRevealed = false,
   onReveal,
+  shortcutsDisabled = false,
 }: LearningControlsProps) {
   const t = useTranslations('LearningMode');
   const { openChat } = useLearningChatToggle();
@@ -65,7 +68,25 @@ export function LearningControls({
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (shortcutsDisabled) return;
+      const target = e.target;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement && target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === ' ' || e.code === 'Space') {
+        if (e.repeat || isMerging || durationSec === 0) return;
+        e.preventDefault();
+        if (isPlaying) {
+          onPause();
+        } else {
+          onPlay();
+        }
+        return;
+      }
       if (e.key === 'Enter') {
         if (isFullReview && !fullReviewRevealed && onReveal) {
           onReveal();
@@ -83,7 +104,22 @@ export function LearningControls({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [validRatings, onSelectRating, instantProceed, onNext, isFullReview, fullReviewRevealed, onReveal, isReviewing]);
+  }, [
+    shortcutsDisabled,
+    validRatings,
+    onSelectRating,
+    instantProceed,
+    onNext,
+    isFullReview,
+    fullReviewRevealed,
+    onReveal,
+    isReviewing,
+    isMerging,
+    durationSec,
+    isPlaying,
+    onPause,
+    onPlay,
+  ]);
 
   return (
     <div className="relative bg-background pb-[max(1rem,env(safe-area-inset-bottom))]">

--- a/components/app/learning/LearningControls.tsx
+++ b/components/app/learning/LearningControls.tsx
@@ -107,16 +107,26 @@ export function LearningControls({
         return;
       }
       if (e.key === 'Enter' || e.key === 'ArrowRight') {
-        e.preventDefault();
+        if (
+          target instanceof HTMLElement &&
+          target.closest(
+            'button, a, select, [role="button"], [role="link"], [role="menuitem"], [role="checkbox"], [role="radio"], [role="tab"]',
+          )
+        ) {
+          return;
+        }
         if (isFullReview && !fullReviewRevealed && onReveal) {
+          e.preventDefault();
           onReveal();
         } else if (
           isAudioReview &&
           !audioAllTargetsRevealed &&
           onRevealAllAudioTargets
         ) {
+          e.preventDefault();
           onRevealAllAudioTargets();
         } else if (!isReviewing) {
+          e.preventDefault();
           onNext();
         }
         return;

--- a/components/app/learning/LearningControls.tsx
+++ b/components/app/learning/LearningControls.tsx
@@ -28,8 +28,13 @@ interface LearningControlsProps {
   isFullReview?: boolean;
   fullReviewRevealed?: boolean;
   onReveal?: () => void;
-  /** When true, window shortcuts (Space, Enter, rating keys) are disabled — e.g. settings or edit dialog open. */
+  /** When true, window shortcuts (Space, Enter, ArrowRight, rating keys) are disabled — e.g. settings or edit dialog open. */
   shortcutsDisabled?: boolean;
+  /** Audio review: Enter / ArrowRight reveals all blurred targets before advancing. */
+  isAudioReview?: boolean;
+  /** When false and `isAudioReview`, Enter / ArrowRight reveals targets instead of next. */
+  audioAllTargetsRevealed?: boolean;
+  onRevealAllAudioTargets?: () => void;
 }
 
 export function LearningControls({
@@ -52,6 +57,9 @@ export function LearningControls({
   fullReviewRevealed = false,
   onReveal,
   shortcutsDisabled = false,
+  isAudioReview = false,
+  audioAllTargetsRevealed = true,
+  onRevealAllAudioTargets,
 }: LearningControlsProps) {
   const t = useTranslations('LearningMode');
   const { openChat } = useLearningChatToggle();
@@ -87,9 +95,16 @@ export function LearningControls({
         }
         return;
       }
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' || e.key === 'ArrowRight') {
+        e.preventDefault();
         if (isFullReview && !fullReviewRevealed && onReveal) {
           onReveal();
+        } else if (
+          isAudioReview &&
+          !audioAllTargetsRevealed &&
+          onRevealAllAudioTargets
+        ) {
+          onRevealAllAudioTargets();
         } else if (!isReviewing) {
           onNext();
         }
@@ -119,6 +134,9 @@ export function LearningControls({
     isPlaying,
     onPause,
     onPlay,
+    isAudioReview,
+    audioAllTargetsRevealed,
+    onRevealAllAudioTargets,
   ]);
 
   return (
@@ -204,10 +222,21 @@ export function LearningControls({
                 <Play className="h-4 w-4" />
               )}
             </Button>
-            {isFullReview && !fullReviewRevealed ? (
+            {isFullReview && !fullReviewRevealed && onReveal ? (
               <Button
                 size="sm"
                 onClick={onReveal}
+                className="flex-[1] gap-2"
+              >
+                {t('actions.reveal')}
+                <Eye className="h-4 w-4" />
+              </Button>
+            ) : isAudioReview &&
+              !audioAllTargetsRevealed &&
+              onRevealAllAudioTargets ? (
+              <Button
+                size="sm"
+                onClick={onRevealAllAudioTargets}
                 className="flex-[1] gap-2"
               >
                 {t('actions.reveal')}


### PR DESCRIPTION
Fixes this bug: "The only minor snag that I see right now (on desktop) is the fact that after each new card the control panel loses focus so I cannot continuously stop/start with the space bar and have to reach for the mouse." 