### PR TITLE
release development into production

### DIFF
--- a/components/app/HomeView.tsx
+++ b/components/app/HomeView.tsx
@@ -227,9 +227,8 @@ export function HomeView({
         </div>
 
         <div className="card-surface space-y-3 p-3">
-          <h2 className="heading-section px-1">
-            {t('collections.carousel.sectionTitle')}
-          </h2>
+          {/* Section title lives inside SegmentedHomeSection now, sharing a
+              row with the compact Course/Custom switcher (top right). */}
           <SegmentedHomeSection
             activeCourseId={courseSettings?.courseId ?? null}
             onNavigateToContent={onNavigateToContent}

--- a/components/app/learning/useLearningMode.ts
+++ b/components/app/learning/useLearningMode.ts
@@ -271,15 +271,6 @@ export function useLearningMode(options: UseLearningModeOptions = {}): LearningS
   const courseSettingsQuery = useQuery(api.features.courses.getActiveCourseSettings, {});
   const activeCourseQuery = useQuery(api.features.courses.getActiveCourse, {});
 
-  // How many reviews the undo button can take back (0 = greyed out). Reactive
-  // on both the review-log stack and courseSettings, so reviews from another
-  // device or a mode/filter switch update the button without local plumbing.
-  const undoableReviewCount =
-    useQuery(
-      api.features.scheduling.getUndoableReviewCount,
-      isAuthenticated ? {} : 'skip',
-    ) ?? 0;
-
   const lastCardRef = useRef<
     Exclude<typeof cardForReviewQuery, undefined> | undefined
   >(undefined);
@@ -353,6 +344,20 @@ export function useLearningMode(options: UseLearningModeOptions = {}): LearningS
       : isAuthenticated && receivedActiveCourseRef.current
         ? lastActiveCourseRef.current
         : undefined;
+
+  // Undo-button state rides on the getCardForReview payload — one
+  // subscription that invalidates once per review, instead of a parallel
+  // `getUndoableReviewCount` subscription. When the deck empties mid-session
+  // the query goes null while the UI may keep showing the just-reviewed card
+  // (the auto-add fallback on `lastReviewingCardRef` below); that ref's
+  // payload predates the review that emptied the queue, so +1 keeps undo
+  // available in that window. Only positivity matters (`canUndo`).
+  const undoableReviewCount =
+    cardForReview != null
+      ? cardForReview.undoableCount
+      : lastReviewingCardRef.current
+        ? lastReviewingCardRef.current.undoableCount + 1
+        : 0;
 
   const reviewCardMutation = useMutation(api.features.scheduling.reviewCard);
   const advanceRadioCardMutation = useMutation(

--- a/components/app/segmented/SegmentedHomeSection.tsx
+++ b/components/app/segmented/SegmentedHomeSection.tsx
@@ -88,32 +88,35 @@ export function SegmentedHomeSection({
       onValueChange={(v) => setCurrentTab(v as 'premade' | 'custom')}
       className="flex flex-col gap-3"
     >
-      <TabsList className="w-full">
-        <TabsTrigger value="premade" className="flex-1">
-          {/* Invisible mirror on the left so the label stays exactly centered
-              within the trigger; the real badge sits to the right of the text. */}
-          {courseOff && <OffBadgeSpacer label={t('sourceBadgeOff')} />}
-          {t('tabPremade')}
-          {courseOff && (
-            <OffBadge
-              isCurrent={currentTab === 'premade'}
-              onReenable={() => reenable('premade')}
-              sourceLabel={t('tabPremade')}
-            />
-          )}
-        </TabsTrigger>
-        <TabsTrigger value="custom" className="flex-1">
-          {customOff && <OffBadgeSpacer label={t('sourceBadgeOff')} />}
-          {t('tabCustom')}
-          {customOff && (
-            <OffBadge
-              isCurrent={currentTab === 'custom'}
-              onReenable={() => reenable('custom')}
-              sourceLabel={t('tabCustom')}
-            />
-          )}
-        </TabsTrigger>
-      </TabsList>
+      {/* Header row: section title on the left, compact source switcher on
+          the right — the switcher no longer spans the full card width. */}
+      <div className="flex items-center justify-between gap-2 px-1">
+        {/* min-w-0 + truncate: the title yields to the switcher when both
+            don't fit (long locales like German on narrow phones). */}
+        <h2 className="heading-section min-w-0 truncate">{t('sectionTitle')}</h2>
+        <TabsList className="shrink-0">
+          <TabsTrigger value="premade">
+            {t('tabPremade')}
+            {courseOff && (
+              <OffBadge
+                isCurrent={currentTab === 'premade'}
+                onReenable={() => reenable('premade')}
+                sourceLabel={t('tabPremade')}
+              />
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="custom">
+            {t('tabCustom')}
+            {customOff && (
+              <OffBadge
+                isCurrent={currentTab === 'custom'}
+                onReenable={() => reenable('custom')}
+                sourceLabel={t('tabCustom')}
+              />
+            )}
+          </TabsTrigger>
+        </TabsList>
+      </div>
 
       <TabsContent value="premade" className="flex flex-col gap-3">
         <PremadeTab summary={summary} activeCourseId={activeCourseId} />
@@ -808,25 +811,6 @@ function CustomChip({
 // ============================================================================
 
 /**
- * Invisible duplicate of the OffBadge used purely as a layout spacer on
- * the left side of the trigger so that the centered text label doesn't
- * shift when the real badge appears on the right. `aria-hidden` keeps it
- * out of the accessibility tree, `invisible` keeps it out of the paint.
- * Class list mirrors the real badge so widths match exactly.
- */
-function OffBadgeSpacer({ label }: { label: string }) {
-  return (
-    <Badge
-      aria-hidden
-      variant="outline"
-      className="invisible h-4 px-1.5 text-[10px] font-medium"
-    >
-      {label}
-    </Badge>
-  );
-}
-
-/**
  * "Off" pill rendered inside a switcher tab whose source is currently
  * excluded by the content-source filter. Clicking behavior is gated by
  * whether the parent tab is selected:
@@ -923,9 +907,10 @@ function OffBadge({
 function SegmentedSkeleton() {
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex gap-2">
-        <div className="h-9 flex-1 animate-pulse rounded-md bg-muted" />
-        <div className="h-9 flex-1 animate-pulse rounded-md bg-muted" />
+      {/* Mirrors the header row: title placeholder left, compact switcher right. */}
+      <div className="flex items-center justify-between gap-2 px-1">
+        <div className="h-6 w-32 animate-pulse rounded bg-muted" />
+        <div className="h-9 w-40 animate-pulse rounded-md bg-muted" />
       </div>
       <div className="-mx-3 flex gap-3 overflow-x-auto px-3 pt-2 pb-5">
         {Array.from({ length: 7 }).map((_, i) => (

--- a/convex/features/scheduling.ts
+++ b/convex/features/scheduling.ts
@@ -277,6 +277,11 @@ export const getCardForReview = query({
        * mirroring what drives `triggerCelebration` in `reviewCard`. 0 when
        * `timezone` is omitted (caller opted out of the side-channel). */
       dailyReviewsToday: v.number(),
+      /** How many reviews the undo button can take back (0..UNDO_DEPTH).
+       * Bundled here so the learn view needs a single subscription that
+       * invalidates once per review — not this query plus a separate
+       * `getUndoableReviewCount`. */
+      undoableCount: v.number(),
     }),
     v.null(),
   ),
@@ -432,7 +437,23 @@ export const getCardForReview = query({
       dailyReviewsToday = displayedActiveReviews(todayStats);
     }
 
-    return { ...current, nextCard: next, dailyReviewsToday };
+    // Undo stack depth under the CURRENT study context — shares
+    // takeUndoableLogs with undoLastReview so the button and the mutation
+    // can't disagree.
+    const undoable = await takeUndoableLogs(
+      ctx,
+      userId,
+      course._id,
+      schedulingMode,
+      studyContentFilter,
+    );
+
+    return {
+      ...current,
+      nextCard: next,
+      dailyReviewsToday,
+      undoableCount: undoable.length,
+    };
   },
 });
 
@@ -930,10 +951,14 @@ export const undoLastReview = mutation({
 });
 
 /**
- * How many reviews the learn-mode undo button can currently take back
+ * How many reviews the undo mechanism can currently take back
  * (0..UNDO_DEPTH): the newest-first run of review-log entries matching the
- * current study context. Reactive on courseSettings, so switching mode/filter
- * greys the button out immediately.
+ * current study context.
+ *
+ * The learn view no longer subscribes to this — it reads the bundled
+ * `undoableCount` field on `getCardForReview` (one invalidation per review
+ * instead of two). Kept as a standalone query for tests, which need to
+ * assert the count in states where `getCardForReview` returns null.
  */
 export const getUndoableReviewCount = query({
   args: {},

--- a/convex/tests/features/schedulingUndo.test.ts
+++ b/convex/tests/features/schedulingUndo.test.ts
@@ -810,4 +810,35 @@ describe("features/scheduling — record/reverse drift guard", () => {
       "fields changed by reviewCard that undoLastReview neither restored nor UNREVERSED_STAT_FIELDS documents as kept",
     ).toEqual([]);
   });
+
+  it("bundles undoableCount into getCardForReview, matching the standalone query", async () => {
+    const t = convexTest(schema, modules);
+    const { cardId, deckId, collectionId } = await seed(t);
+    // Second due card so getCardForReview stays non-null after the first
+    // card's review pushes its dueDate forward.
+    await addCard(t, deckId, collectionId);
+    const asUser = t.withIdentity({ subject: "user_A" });
+
+    let card = await asUser.query(api.features.scheduling.getCardForReview, {});
+    expect(card?.undoableCount).toBe(0);
+
+    await asUser.mutation(api.features.scheduling.reviewCard, {
+      cardId,
+      rating: "stillLearning",
+      timezone: "UTC",
+    });
+
+    card = await asUser.query(api.features.scheduling.getCardForReview, {});
+    expect(card).not.toBeNull();
+    expect(card?.undoableCount).toBe(1);
+    expect(card?.undoableCount).toBe(
+      await asUser.query(api.features.scheduling.getUndoableReviewCount, {}),
+    );
+
+    await asUser.mutation(api.features.scheduling.undoLastReview, {
+      timezone: "UTC",
+    });
+    card = await asUser.query(api.features.scheduling.getCardForReview, {});
+    expect(card?.undoableCount).toBe(0);
+  });
 });

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -1129,15 +1129,24 @@ export const SUPPORTED_LANGUAGES: Language[] = [
     regionLabel: 'Vietnam',
     geminiBcp47: 'vi-VN',
     azureSttLocale: 'vi-VN',
-    name: 'Vietnamese',
-    nativeName: 'Tiếng Việt',
+    displayNameOverrides: { en: 'Vietnamese (Northern)', de: 'Vietnamesisch (Nord)' },
+    name: 'Vietnamese (Northern)',
+    nativeName: 'Tiếng Việt (miền Bắc)',
     flag: '🇻🇳',
     category: 'asian-southeast',
     llmSupportTier: 'tier1',
     ttsProvider: 'gemini',
+    // `vi-VN` can't pin the dialect, so it's named in the prompt. Must be set
+    // explicitly: the default strips the "(Northern)" parenthetical from
+    // `name` and would fall back to unpinned "Vietnamese".
+    ttsPromptName: 'Northern Vietnamese',
     needsRomanization: false,
     supportsKaraoke: true,
     supportsStt: true,
+    // Canonical dialect name for the translation prompt (mirrors ttsPromptName)
+    // so the model produces Northern vocabulary/particles, not a regionless mix.
+    translationName: 'Northern Vietnamese',
+    translationPromptNotes: 'Northern (Hanoi) Vietnamese vocabulary and particles.',
     translationVersion: 2,
   },
   {


### PR DESCRIPTION
Brings the latest development commit into production: home content-section header (Course/Custom switcher top right), `undoableCount` bundled into `getCardForReview` (one subscription per review), and Vietnamese pinned to the Northern dialect (no content-version bumps).