### PR TITLE
Adds Icelandic

### DIFF
--- a/components/course/LanguageSelector.tsx
+++ b/components/course/LanguageSelector.tsx
@@ -158,12 +158,20 @@ export function LanguageSelector({
                   >
                     <span className="text-2xl shrink-0">{language.flag}</span>
                     <div className="flex-1 min-w-0">
-                      {/* `llmSupportTier` stays internal-only — tier2 languages
-                          no longer get a user-facing "Experimental" badge. */}
+                      {/* `llmSupportTier` stays internal-only — the badge is
+                          driven by the per-language `experimental` flag. */}
                       <div className="flex items-center gap-2 flex-wrap">
                         <p className="font-semibold text-sm leading-tight break-words">
                           {localizedName}
                         </p>
+                        {language.experimental && (
+                          <span
+                            className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
+                            title={t('experimentalBadgeTooltip')}
+                          >
+                            {t('experimentalBadge')}
+                          </span>
+                        )}
                       </div>
                       {language.nativeName.toLowerCase() !== localizedName.toLowerCase() ? (
                         <p className="text-muted-xs break-words">

--- a/components/landing/languages-section.tsx
+++ b/components/landing/languages-section.tsx
@@ -22,6 +22,7 @@ export function LanguagesSection() {
         code: l.code,
         flag: l.flag,
         name: getLocalizedLanguageNameByCode(l.code, locale),
+        experimental: l.experimental ?? false,
       }))
       .sort((a, b) => a.name.localeCompare(b.name, locale));
   }, [locale]);
@@ -52,9 +53,15 @@ export function LanguagesSection() {
             <li
               key={lang.code}
               className="flex items-center gap-2 rounded-full border border-border/40 bg-card px-3.5 py-1.5 text-sm md:text-base"
+              title={lang.experimental ? t('experimentalBadgeTooltip') : undefined}
             >
               <span aria-hidden="true">{lang.flag}</span>
               <span>{lang.name}</span>
+              {lang.experimental && (
+                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                  {t('experimentalBadge')}
+                </span>
+              )}
             </li>
           ))}
           <li>

--- a/convex/tests/features/translationCodes.test.ts
+++ b/convex/tests/features/translationCodes.test.ts
@@ -30,6 +30,7 @@ const EXPECTED_GOOGLE: Record<string, string> = {
   nl: 'nl',
   sv: 'sv',
   da: 'da',
+  is: 'is',
   fi: 'fi',
   el: 'el',
   hi: 'hi',

--- a/convex/tests/lib/stt/languageCodes.test.ts
+++ b/convex/tests/lib/stt/languageCodes.test.ts
@@ -49,6 +49,8 @@ const EXPECTED_AZURE: Record<string, string> = {
   id: 'id-ID',
   sv: 'sv-SE',
   da: 'da-DK',
+  // Symmetric default (no explicit azureSttLocale) — live-verified Jul 2026.
+  is: 'is-IS',
   fi: 'fi-FI',
   nl: 'nl-NL',
   el: 'el-GR',

--- a/convex/tests/lib/tts/languageCodes.test.ts
+++ b/convex/tests/lib/tts/languageCodes.test.ts
@@ -36,6 +36,7 @@ const EXPECTED_GEMINI: Record<string, string> = {
   nl: 'nl-NL',
   sv: 'sv-SE',
   da: 'da-DK',
+  is: 'is-IS',
   fi: 'fi-FI',
   el: 'el-GR',
   hi: 'hi-IN',

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -210,6 +210,14 @@ export interface Language {
    * stays available for any rows already referencing them.
    */
   hiddenFromPicker?: boolean;
+  /**
+   * When `true`, picker surfaces (`LanguageSelector`) show a user-facing
+   * "Experimental" badge next to this language. Independent of the
+   * internal-only `llmSupportTier` — set it on newly added languages while
+   * translation/voice quality is still being tuned, and remove the flag once
+   * the language has proven itself.
+   */
+  experimental?: true;
 
   // --- Provider locale codes + display overrides --------------------------
   // Single source of truth for the per-language data that used to live in
@@ -827,6 +835,26 @@ export const SUPPORTED_LANGUAGES: Language[] = [
     supportsKaraoke: true,
     supportsStt: true,
     translationVersion: 2,
+  },
+  {
+    code: 'is',
+    displayCode: 'is',
+    regionLabel: 'Iceland',
+    // `is-IS` is a documented Gemini TTS locale (Preview stage as of Jul 2026).
+    geminiBcp47: 'is-IS',
+    // No `azureSttLocale`: the symmetric default resolves to `is-IS`, which
+    // Azure Fast Transcription accepts (verified with a live probe, Jul 2026 —
+    // the docs table alone has been wrong before, see sw_tz).
+    name: 'Icelandic',
+    nativeName: 'Íslenska',
+    flag: '🇮🇸',
+    category: 'germanic',
+    llmSupportTier: 'tier2',
+    ttsProvider: 'gemini',
+    needsRomanization: false,
+    supportsKaraoke: true,
+    supportsStt: true,
+    experimental: true,
   },
   {
     code: 'fi',

--- a/lib/voices.ts
+++ b/lib/voices.ts
@@ -228,6 +228,7 @@ export const VOICE_POOLS: Record<string, Voice[]> = {
   sv: [...buildChirp3Pool('sv-SE', 'Sweden'), ...GEMINI_CORE],
   nb: [...buildChirp3Pool('nb-NO', 'Norway'), ...GEMINI_CORE],
   da: [...buildChirp3Pool('da-DK', 'Denmark'), ...GEMINI_CORE],
+  is: [...GEMINI_CORE],
   fi: [...buildChirp3Pool('fi-FI', 'Finland'), ...GEMINI_CORE],
   nl: [...buildChirp3Pool('nl-NL', 'Netherlands'), ...GEMINI_CORE],
   el: [...buildChirp3Pool('el-GR', 'Greece'), ...GEMINI_CORE],

--- a/messages/de.json
+++ b/messages/de.json
@@ -592,6 +592,8 @@
   "LanguageSelector": {
     "searchPlaceholder": "Sprachen suchen…",
     "noResults": "Keine Sprache passt.",
+    "experimentalBadge": "Experimentell",
+    "experimentalBadgeTooltip": "Neu hinzugefügt – Übersetzungs- und Stimmqualität werden noch optimiert. Bitte melde Probleme.",
     "categories": {
       "germanic": "Germanisch & Nordisch",
       "romance": "Romanisch",

--- a/messages/en.json
+++ b/messages/en.json
@@ -592,6 +592,8 @@
   "LanguageSelector": {
     "searchPlaceholder": "Search languages…",
     "noResults": "No languages match.",
+    "experimentalBadge": "Experimental",
+    "experimentalBadgeTooltip": "Newly added — translation and voice quality are still being tuned. Please report issues.",
     "categories": {
       "germanic": "Germanic & Nordic",
       "romance": "Romance",

--- a/messages/landing/de.json
+++ b/messages/landing/de.json
@@ -249,6 +249,8 @@
     "title": "Eine Methode,",
     "titleHighlight": "{count}+ Sprachen",
     "lead": "Jede Sprache kommt mit hochwertigem Audio. Lerne eine Sprache oder mehrere parallel.",
+    "experimentalBadge": "Experimentell",
+    "experimentalBadgeTooltip": "Neu hinzugefügt – Übersetzungs- und Stimmqualität werden noch optimiert.",
     "missingPill": "Deine Sprache fehlt? Sag uns Bescheid"
   },
   "testimonials": {
@@ -412,7 +414,7 @@
       {
         "question": "Welche Sprachen unterstützt Flexling?",
         "answer": [
-          "In Flexling kannst du folgende Sprachen lernen: Englisch, Spanisch (Spanien, Lateinamerika und eine gemischte Spanien-+-Lateinamerika-Variante), Katalanisch, Französisch, Deutsch, Italienisch, Rumänisch, Portugiesisch (Brasilien und Portugal), Niederländisch, Schwedisch, Norwegisch (Bokmål), Dänisch, Finnisch, Estnisch, Lettisch, Litauisch, Griechisch, Polnisch, Tschechisch, Slowakisch, Ukrainisch, Kroatisch, Serbisch, Slowenisch, Ungarisch, Russisch, Hindi, Bengalisch, Tamil, Telugu, Hebräisch, Türkisch, Persisch, Arabisch (Hocharabisch sowie saudische, ägyptische, irakische und levantinische Dialekte), Chinesisch (vereinfacht und traditionell), Kantonesisch (vereinfacht und traditionell), Japanisch, Koreanisch, Vietnamesisch (Nord und Süd), Thai, Indonesisch, Malaiisch, Filipino und Swahili (Kenia und Tansania) – weitere Sprachen kommen regelmäßig dazu.",
+          "In Flexling kannst du folgende Sprachen lernen: Englisch, Spanisch (Spanien, Lateinamerika und eine gemischte Spanien-+-Lateinamerika-Variante), Katalanisch, Französisch, Deutsch, Italienisch, Rumänisch, Portugiesisch (Brasilien und Portugal), Niederländisch, Schwedisch, Norwegisch (Bokmål), Dänisch, Isländisch, Finnisch, Estnisch, Lettisch, Litauisch, Griechisch, Polnisch, Tschechisch, Slowakisch, Ukrainisch, Kroatisch, Serbisch, Slowenisch, Ungarisch, Russisch, Hindi, Bengalisch, Tamil, Telugu, Hebräisch, Türkisch, Persisch, Arabisch (Hocharabisch sowie saudische, ägyptische, irakische und levantinische Dialekte), Chinesisch (vereinfacht und traditionell), Kantonesisch (vereinfacht und traditionell), Japanisch, Koreanisch, Vietnamesisch (Nord und Süd), Thai, Indonesisch, Malaiisch, Filipino und Swahili (Kenia und Tansania) – weitere Sprachen kommen regelmäßig dazu.",
           "Wird deine Sprache nicht unterstützt? Lass es uns wissen und wir werden versuchen, sie zu priorisieren."
         ]
       },

--- a/messages/landing/en.json
+++ b/messages/landing/en.json
@@ -249,6 +249,8 @@
     "title": "One method,",
     "titleHighlight": "{count}+ languages",
     "lead": "Every language comes with high quality audio. Pick one or learn several side by side.",
+    "experimentalBadge": "Experimental",
+    "experimentalBadgeTooltip": "Newly added — translation and voice quality are still being tuned.",
     "missingPill": "Missing a language? Let us know"
   },
   "testimonials": {
@@ -412,7 +414,7 @@
       {
         "question": "What languages does Flexling support?",
         "answer": [
-          "You can learn the following languages in Flexling: English, Spanish (Spain, Latin America, and a mixed Spain + Latin America variant), Catalan, French, German, Italian, Romanian, Portuguese (Brazil and Portugal), Dutch, Swedish, Norwegian (Bokmål), Danish, Finnish, Estonian, Latvian, Lithuanian, Greek, Polish, Czech, Slovak, Ukrainian, Croatian, Serbian, Slovenian, Hungarian, Russian, Hindi, Bengali, Tamil, Telugu, Hebrew, Turkish, Persian, Arabic (Modern Standard plus Saudi, Egyptian, Iraqi, and Levantine dialects), Chinese (Simplified and Traditional), Cantonese (Simplified and Traditional), Japanese, Korean, Vietnamese (Northern and Southern), Thai, Indonesian, Malay, Filipino, and Swahili (Kenya and Tanzania) — with more languages being added regularly.",
+          "You can learn the following languages in Flexling: English, Spanish (Spain, Latin America, and a mixed Spain + Latin America variant), Catalan, French, German, Italian, Romanian, Portuguese (Brazil and Portugal), Dutch, Swedish, Norwegian (Bokmål), Danish, Icelandic, Finnish, Estonian, Latvian, Lithuanian, Greek, Polish, Czech, Slovak, Ukrainian, Croatian, Serbian, Slovenian, Hungarian, Russian, Hindi, Bengali, Tamil, Telugu, Hebrew, Turkish, Persian, Arabic (Modern Standard plus Saudi, Egyptian, Iraqi, and Levantine dialects), Chinese (Simplified and Traditional), Cantonese (Simplified and Traditional), Japanese, Korean, Vietnamese (Northern and Southern), Thai, Indonesian, Malay, Filipino, and Swahili (Kenya and Tanzania) — with more languages being added regularly.",
           "Is your language not supported? Let us know and we will try to prioritize it."
         ]
       },

--- a/tests/components/course/LanguageSelector.test.tsx
+++ b/tests/components/course/LanguageSelector.test.tsx
@@ -36,6 +36,9 @@ const messages = {
   LanguageSelector: {
     searchPlaceholder: "Search languages…",
     noResults: "No languages match.",
+    experimentalBadge: "Experimental",
+    experimentalBadgeTooltip:
+      "Newly added — translation and voice quality are still being tuned. Please report issues.",
     categories: {
       germanic: "Germanic & Nordic",
       romance: "Romance",

--- a/tests/unit/lib/textCompare/languageConfig.test.ts
+++ b/tests/unit/lib/textCompare/languageConfig.test.ts
@@ -29,6 +29,7 @@ const EXPECTED_COMPARE: Record<string, { locale: string; hasWordBoundaries: bool
   nl: { locale: 'nl', hasWordBoundaries: true },
   sv: { locale: 'sv', hasWordBoundaries: true },
   da: { locale: 'da', hasWordBoundaries: true },
+  is: { locale: 'is', hasWordBoundaries: true },
   fi: { locale: 'fi', hasWordBoundaries: true },
   el: { locale: 'el', hasWordBoundaries: true },
   hi: { locale: 'hi', hasWordBoundaries: true },


### PR DESCRIPTION
Adds Icelandic (`is`) as an experimental language:

- New catalog entry in `lib/languages.ts` (Gemini TTS `is-IS`, Azure STT via symmetric default, karaoke + STT enabled)
- Experimental badge shown in the course language selector and on the landing page languages section (EN/DE strings)
- Voice config and language-code test coverage updated